### PR TITLE
feat(test infra): add docker-compose and NGINX setup for test server

### DIFF
--- a/environments/test/docker-compose.yml
+++ b/environments/test/docker-compose.yml
@@ -1,0 +1,64 @@
+services:
+  db:
+    container_name: modgy_db
+    image: postgres:13.7-alpine
+    ports:
+      - "6432:5432"
+    restart: unless-stopped
+    env_file:
+      - .env
+    volumes:
+      - modgy_postgres_data:/var/lib/postgresql/data/
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U admin -d pethotel"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  back:
+    container_name: modgy_back
+    image: modgy/modgy-back:latest
+    restart: unless-stopped
+    env_file:
+      - .env
+    depends_on:
+      db:
+        condition: service_healthy
+
+  front:
+    container_name: modgy-front
+    image: modgy/modgy-front:latest
+    restart: unless-stopped
+    env_file:
+      - .env
+
+  nginx:
+    container_name: modgy-nginx
+    image: nginx:stable-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    restart: unless-stopped
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./log/nginx:/var/log/nginx/
+      - ./ssl/certs:/etc/nginx/ssl/certs
+      - ./ssl/private:/etc/nginx/ssl/private
+    
+    depends_on:
+      back:
+        condition: service_healthy
+      front:
+        condition: service_healthy
+    
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+    
+
+volumes:
+  modgy_postgres_data:
+    external: true

--- a/environments/test/nginx.conf
+++ b/environments/test/nginx.conf
@@ -1,0 +1,87 @@
+server {
+    listen 80;
+    server_name 212.109.192.9;
+    server_tokens off;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name 212.109.192.9;
+    server_tokens off;
+
+    ssl_certificate /etc/nginx/ssl/certs/selfsigned.crt;
+    ssl_certificate_key /etc/nginx/ssl/private/selfsigned.key;
+
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
+
+    location @proxy_backend {
+        proxy_pass http://back:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+
+    location @proxy_frontend {
+        proxy_pass http://front:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+# Backend
+    location /swagger-ui-custom.html {
+        try_files $uri @proxy_backend;
+    }
+
+    location /swagger-ui/ {
+        try_files $uri @proxy_backend;
+    }
+
+    location /v3/api-docs {
+        try_files $uri @proxy_backend;
+    } 
+
+    location /users {
+        try_files $uri @proxy_backend;
+    }
+
+    location /rooms {
+        try_files $uri @proxy_backend;
+    }
+
+    location /pets {
+        try_files $uri @proxy_backend;
+    }
+
+    location /owners {
+        try_files $uri @proxy_backend;
+    }
+
+    location /categories {
+        try_files $uri @proxy_backend;
+    }
+
+    location /bookings {
+        try_files $uri @proxy_backend;
+    }
+
+
+# Frontend
+    location / {
+        try_files $uri @proxy_frontend;
+    }
+
+}


### PR DESCRIPTION
Introduce Docker Compose and NGINX with basic configuration for test server infrastructure. This setup provides essential components for managing test server dependencies and routing.