### PR TITLE
feat(test infra): Add CORS headers to nginx configuration for backend proxy #7

### DIFF
--- a/environments/test/nginx.conf
+++ b/environments/test/nginx.conf
@@ -30,6 +30,11 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
+        add_header 'Access-Control-Max-Age' 86400;
     }
 
 


### PR DESCRIPTION
Configured nginx to support CORS by adding necessary headers.