### PR TITLE
feat(test_env): Update PostgreSQL version from 13 to 17 in Docker Compose #1

### DIFF
--- a/environments/test/docker-compose.yml
+++ b/environments/test/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   db:
     container_name: modgy_db
-    image: postgres:13.7-alpine
+    image: postgres:17-alpine3.20
     ports:
       - "6432:5432"
     restart: unless-stopped


### PR DESCRIPTION
- Upgraded PostgreSQL version in Docker Compose from 13 to 17 for the test server